### PR TITLE
add type constraints to number and stringbytes functions

### DIFF
--- a/get.go
+++ b/get.go
@@ -5,7 +5,7 @@ import (
 )
 
 func Get[T any](input any, validators ...Validator[T]) (T, error) {
-	return get[T](input, validators...)
+	return get(input, validators...)
 }
 
 func get[T any](input any, validators ...Validator[T]) (T, error) {

--- a/get_test.go
+++ b/get_test.go
@@ -16,13 +16,11 @@ func TestGetNum(t *testing.T) {
 	_, err = Get[float32](numInf, Min(float32(0.1)), Eq(float32(0.12)))
 	assert.NoError(t, err)
 
-	var bytesInf interface{}
-	bytesInf = []byte("abcdefg")
+	bytesInf := []byte("abcdefg")
 	_, err = Get[[]byte](bytesInf, ContainsBytes([]byte("cde")))
 	assert.NoError(t, err)
 
-	var strInf interface{}
-	strInf = []byte("iamlyon")
+	strInf := []byte("iamlyon")
 	_, err = Get[string](strInf)
 	assert.Error(t, err)
 }

--- a/number.go
+++ b/number.go
@@ -4,7 +4,13 @@ import (
 	"errors"
 )
 
-func Min[T int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64 | float32 | float64](min T, errMsg ...string) ValidatorFunc[T] {
+type number interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |
+		~float32 | ~float64
+}
+
+func Min[T number](min T, errMsg ...string) ValidatorFunc[T] {
 	return ValidatorFunc[T](func(num T) error {
 		if num < min {
 			if len(errMsg) > 0 {
@@ -16,7 +22,7 @@ func Min[T int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 |
 	})
 }
 
-func Max[T int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64 | float32 | float64](max T, errMsg ...string) ValidatorFunc[T] {
+func Max[T number](max T, errMsg ...string) ValidatorFunc[T] {
 	return ValidatorFunc[T](func(num T) error {
 		if num > max {
 			if len(errMsg) > 0 {

--- a/number_test.go
+++ b/number_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type customInt int
+
 func TestNumberMin(t *testing.T) {
 	var n1 int = 256
 	err := Validate[int](n1, Min(1000, ""))
@@ -14,6 +16,8 @@ func TestNumberMin(t *testing.T) {
 	var n2 uint = 256
 	err = Validate[uint](n2, Min(uint(255), ""))
 	assert.NoError(t, err)
+
+	assert.Error(t, Validate[customInt](customInt(256), Min(customInt(1000), "")))
 }
 
 func TestNumberMax(t *testing.T) {
@@ -24,6 +28,8 @@ func TestNumberMax(t *testing.T) {
 	var n2 uint = 256
 	err = Validate[uint](n2, Max(uint(1000)))
 	assert.NoError(t, err)
+
+	assert.Error(t, Validate[customInt](customInt(1000), Max(customInt(256), "")))
 }
 
 func TestNumberLimit(t *testing.T) {

--- a/stringbytes.go
+++ b/stringbytes.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 )
 
-func MinLen[T string | []byte](minLen int, errMsg ...string) ValidatorFunc[T] {
+func MinLen[T ~string | ~[]byte](minLen int, errMsg ...string) ValidatorFunc[T] {
 	return ValidatorFunc[T](func(filed T) error {
 		l := len(filed)
 		if l < minLen {
@@ -17,7 +17,7 @@ func MinLen[T string | []byte](minLen int, errMsg ...string) ValidatorFunc[T] {
 	})
 }
 
-func MaxLen[T string | []byte](maxLen int, errMsg ...string) ValidatorFunc[T] {
+func MaxLen[T ~string | ~[]byte](maxLen int, errMsg ...string) ValidatorFunc[T] {
 	return ValidatorFunc[T](func(filed T) error {
 		l := len(filed)
 		if l > maxLen {

--- a/stringbytes_test.go
+++ b/stringbytes_test.go
@@ -6,6 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type (
+	customString string
+	customBytes  []byte
+)
+
 func TestStrBytesLen(t *testing.T) {
 	var str1 = "i am developer"
 	err := Validate[string](str1, MinLen[string](25, "字符串长度太短"), MaxLen[string](100))
@@ -15,11 +20,17 @@ func TestStrBytesLen(t *testing.T) {
 	err = Validate[string](str2, MinLen[string](2), MaxLen[string](6))
 	assert.NoError(t, err)
 
+	err = Validate[customString](customString("f"), MinLen[customString](25), MaxLen[customString](100))
+	assert.Error(t, err)
+
 	var bytes1 = []byte("bytes value")
 	err = Validate[[]byte](bytes1, MinLen[[]byte](15, "字节数组长度太短"), MaxLen[[]byte](30))
 	assert.Error(t, err)
 
 	var bytes2 = []byte("bytes value....")
 	err = Validate[[]byte](bytes2, MinLen[[]byte](1), MaxLen[[]byte](10, "超出数组长度最大值"))
+	assert.Error(t, err)
+
+	err = Validate[customBytes](customBytes("custom_bytes"), MinLen[customBytes](25), MaxLen[customBytes](100))
 	assert.Error(t, err)
 }


### PR DESCRIPTION
This PR will allow the use of defined types, which are subtypes of numbers, strings, and bytes in some validators.

```go
type myStirng string

func main() {
	hvalid.Validate(myStirng("ff"), hvalid.MinLen[myStirng](3))
}

```